### PR TITLE
add a shorthand to jump to the history of the job

### DIFF
--- a/templates/matrix_message.tmpl
+++ b/templates/matrix_message.tmpl
@@ -15,8 +15,9 @@
 
 {{ $baseURL := getBaseUrl (index .Buildset.Builds 0).WebURL }}
 {{ $buildsetURL := print $baseURL "/t/" .Tenant "/buildset/" .Buildset.UUID }}
+{{ $jobHistorytURL := print $baseURL "/t/" .Tenant "/builds?job_name=" .Buildset.JobName }}
 
-<b>Buildset:</b> <a href="{{ $buildsetURL }}">{{ .Buildset.Result }}</a><br>
+<b>Buildset:</b> <a href="{{ $buildsetURL }}">{{ .Buildset.Result }}</a> (<a href="{{ $jobHistorytURL }}">History</a>)<br>
 <b>Builds:</b>
 <ul>
   {{ range .Buildset.Builds }}


### PR DESCRIPTION
The intention of this change is to provide a shorthand to simplify checking failed jobs if they fail also on other branches or reverted to a good state.